### PR TITLE
Snap borders capability

### DIFF
--- a/src/animation.js
+++ b/src/animation.js
@@ -105,6 +105,10 @@ var Animations = function(carousel) {
 
     function animationRepeat() {
         var currentTime = Date.now() - startTime;
+        
+        if (options.snap_borders) {
+        	_this.currentLandPos = clamp( -(vars.allSlidesWidth - slides.parent().width()), 0, _this.currentLandPos);
+        }
 
         slides.trigger('changePos');
 
@@ -164,4 +168,16 @@ $.fn.translate3d = function (x, y) {
             };
         }
     }
+};
+
+global.clamp = function (min, max, value) {
+	  return Math.min(Math.max(value, min), max);
+};
+
+global.getCurrentTotalWidth = function (inSlides) { // Returns the total number of pixels for each items
+	var width = 0;
+	inSlides.children().each(function() {
+	    width += $(this).outerWidth( true );
+	});
+	return width;
 };

--- a/src/carousel.js
+++ b/src/carousel.js
@@ -35,7 +35,8 @@ module.exports = {
             parent_width: _this.options.parent_width,
             velocity: 0,
             slideHeight: element.children().height(),
-            direction: 1
+            direction: 1,
+            allSlidesWidth: getCurrentTotalWidth(element)
         };
 
         element.end_animation = true;

--- a/src/external_funcs.js
+++ b/src/external_funcs.js
@@ -29,6 +29,7 @@ module.exports = {
 
             vars.slideHeight = $el.children().height();
 
+            vars.allSlidesWidth = getCurrentTotalWidth($el);
             // Set panning veloicity to zero
             vars.velocity = 0;
 
@@ -43,6 +44,7 @@ module.exports = {
 
         slides.removeSlide = function (index) {
             carousel.$el.children(':nth-child(' + ((index + 1) || 0) + ')').remove();
+            carousel.vars.allSlidesWidth = getCurrentTotalWidth(carousel.$el);
             //this.reload();
         };
 

--- a/src/itemslide.js
+++ b/src/itemslide.js
@@ -19,7 +19,8 @@ var defaults = {
     pan_threshold: 0.3, //Precentage of slide width
     disable_autowidth: false,
     parent_width: false,
-    swipe_out: false //Enable the swipe out feature - enables swiping items out of the carousel
+    swipe_out: false, //Enable the swipe out feature - enables swiping items out of the carousel
+    snap_borders: false // Restricts the movements to the borders instead of the middle
 };
 
 

--- a/src/navigation.js
+++ b/src/navigation.js
@@ -166,6 +166,10 @@ var Navigation = function (carousel, anim) {
             if (options.disable_slide) { //Check if user disabled slide - if didn't than go to position according to distance from when horizontal panning started
                 return;
             }
+            
+            if (options.snap_borders) {
+            	anim.currentLandPos = clamp( -(vars.allSlidesWidth - $el.parent().width()), 0, anim.currentLandPos);
+            }
 
             vertical_pan = false;
 


### PR DESCRIPTION
Added clamping values for currentLandPos if the option snap_borders is true to restrict it to the borders of the itemslider.  

There is also now a new public variables that refreshes when the list of items changes called 'allSlidesWidth'.  This variable is needed to know the max value that the user can swipe right.  Here is an image explaining the process.
![bordersnapingmethod](https://cloud.githubusercontent.com/assets/6496893/9887751/3ef4372a-5bbf-11e5-8677-e05ed435ddd0.png)


NOTES:  
- The out of bounds swipe are a bit more sensitive when snap_borders is on 
- Was not able to test with addSlide, but I'm pretty sure the method is structured correctly