### PR TITLE
Fix TypeError

### DIFF
--- a/src/polyfills.js
+++ b/src/polyfills.js
@@ -35,10 +35,12 @@ if (typeof Object.create !== "function") {
 
 // Stuff to add for compatibility with Zepto
 $.fn.outerWidth = function () {
-    var el = $(this)[0];
-    var width = el.offsetWidth;
-    var style = getComputedStyle(el);
-
-    width += parseInt(style.marginLeft) + parseInt(style.marginRight);
-    return width;
+    if($(this)[0] instanceof Element){
+        var el = $(this)[0];
+        var width = el.offsetWidth;
+        var style = getComputedStyle(el);
+    
+        width += parseInt(style.marginLeft) + parseInt(style.marginRight);
+        return width;
+	}
 };


### PR DESCRIPTION
Sometimes I've got an error "TypeError: Argument 1 of Window.getComputedStyle does not implement interface Element." when using itemSlide. I suggest to add this checking of argument's type.