### PR TITLE
Update navigation.js to avoid divide by 0 error

### DIFF
--- a/src/navigation.js
+++ b/src/navigation.js
@@ -226,6 +226,8 @@ var Navigation = function (carousel, anim) {
 
                 //Calculate deltaTime for calculation of velocity
                 var deltaTime = (Date.now() - swipeStartTime);
+                //Verify delta is > 0 to avoid divide by 0 error
+                deltaTime++;
                 vars.velocity = -(touch.pageX - startPointX) / deltaTime;
 
                 if (vars.velocity > 0) { //Set direction


### PR DESCRIPTION
Found this error implementing on a desktop that was rendering like a phone. On a click, the swipeStartTime is nearly identical to Date.now().  A majority of the time it would return 0, making the velocity calculation return NaN.  This should cover it easy enough.